### PR TITLE
Support Upload of Attachments

### DIFF
--- a/src/main/resources/default_code/service/FrappeSiteService.kt
+++ b/src/main/resources/default_code/service/FrappeSiteService.kt
@@ -364,16 +364,16 @@ open class FrappeSiteService(
         body: RequestBody,
         fileName: String,
         isPrivate: Boolean,
-        docType: KClass<D>,
-        name: String,
+        link: FrappeLinkField<D>,
     ): FraplinResult<Unit> {
         return requestBuilder {
-            postMultipartBody {
-                setType(MultipartBody.FORM)
-                addFormDataPart("file", fileName, body)
-                addFormDataPart("is_private", if (isPrivate) "1" else "0")
-                addFormDataPart("doctype", docType.getDocTypeName().name)
-                addFormDataPart("docname", name)
+            multipartBody {
+                setDefaultFileUploadArgs(
+                    body = body,
+                    fileName = fileName,
+                    isPrivate = isPrivate,
+                    link = link,
+                )
             }
             url("$baseUrl/api/method/upload_file")
         }.send {
@@ -509,14 +509,15 @@ open class FrappeSiteService(
             fileName: String,
             isPrivate: Boolean,
             link: FrappeLinkField<D>,
-            fieldName: KProperty1<D, FrappeAttachField?>,
+            fieldName: KProperty1<D, FrappeAttachField?>? = null,
         ) {
             setType(MultipartBody.FORM)
             addFormDataPart("file", fileName, body)
             addFormDataPart("is_private", if (isPrivate) "1" else "0")
             addFormDataPart("doctype", link.docType.getDocTypeName().name)
             addFormDataPart("docname", link.value)
-            addFormDataPart("fieldname", fieldName.name)
+            if (fieldName != null)
+                addFormDataPart("fieldname", fieldName.name)
         }
     }
 }


### PR DESCRIPTION
Function to Upload a File and Link ist directly to a Document as an Attachment. On Success Frappe returns only Status Code 200, without any message.

Example Usage

```kotlin
        service.uploadAttachment(
            body = File("./test.pdf").asRequestBody(),
            fileName = "test",
            name = "6e6f4cd3",
            isPrivate = true,
            docType = Invoice::class
        )
```

Leading to Result in Document View

![image](https://github.com/user-attachments/assets/841fd096-883e-44ac-b3c4-4a3562685ddf)
